### PR TITLE
feat(rules): add correction rule for mistyped kubectl subcommands

### DIFF
--- a/tests/rules/test_kubectl_unknown_command.py
+++ b/tests/rules/test_kubectl_unknown_command.py
@@ -1,0 +1,58 @@
+import pytest
+from thebleep.rules.kubectl_unknown_command import match, get_new_command
+from thebleep.types import Command
+
+
+# kubectl >= 1.26: single suggestion
+output_single = '''error: unknown command "gat" for "kubectl"
+
+Did you mean this?
+\tget
+
+'''
+
+# kubectl >= 1.26: multiple suggestions
+output_multiple = '''error: unknown command "decsribe" for "kubectl"
+
+Did you mean this?
+\tdescribe
+\tdelete
+
+'''
+
+# kubectl < 1.26: slightly different wording
+output_old = '''error: unknown command "aply" for "kubectl"
+
+Did you mean this?
+        apply
+
+'''
+
+
+@pytest.mark.parametrize('command', [
+    Command('kubectl gat pods', output_single),
+    Command('kubectl decsribe pod my-pod', output_multiple),
+    Command('kubectl aply -f deploy.yaml', output_old)])
+def test_match(command):
+    assert match(command)
+
+
+@pytest.mark.parametrize('command', [
+    Command('kubectl get pods', ''),
+    Command('kubectl get pods', 'NAME   READY   STATUS\nmy-pod   1/1   Running'),
+    Command('vim gat', output_single)])
+def test_not_match(command):
+    assert not match(command)
+
+
+@pytest.mark.parametrize('command, new_command', [
+    (Command('kubectl gat pods', output_single),
+     ['kubectl get pods']),
+    (Command('kubectl gat pods -n kube-system', output_single),
+     ['kubectl get pods -n kube-system']),
+    (Command('kubectl decsribe pod my-pod', output_multiple),
+     ['kubectl describe pod my-pod', 'kubectl delete pod my-pod']),
+    (Command('kubectl aply -f deploy.yaml', output_old),
+     ['kubectl apply -f deploy.yaml'])])
+def test_get_new_command(command, new_command):
+    assert get_new_command(command) == new_command

--- a/thebleep/rules/kubectl_unknown_command.py
+++ b/thebleep/rules/kubectl_unknown_command.py
@@ -1,0 +1,52 @@
+import re
+from thebleep.utils import replace_argument, for_app
+
+
+# kubectl prints `unknown command "<cmd>"` followed by one or more suggestions:
+#
+#   error: unknown command "gat" for "kubectl"
+#
+#   Did you mean this?
+#           get
+#
+# Older kubectl (before 1.26) used slightly different wording but kept the
+# `Did you mean` block.
+SUGGESTION = re.compile(r'^\s+(\S+)\s*$', re.MULTILINE)
+
+
+def _get_suggestions(output):
+    """Return the commands kubectl itself suggested, in its order."""
+    suggestions = []
+    after_marker = False
+    for line in output.split('\n'):
+        if 'Did you mean' in line:
+            after_marker = True
+            continue
+        if not after_marker:
+            continue
+
+        m = SUGGESTION.match(line)
+        if m:
+            suggestions.append(m.group(1))
+        elif line.strip():
+            # The suggestions are over.
+            break
+
+    return suggestions
+
+
+@for_app('kubectl', at_least=1)
+def match(command):
+    return 'unknown command' in command.output
+
+
+def get_new_command(command):
+    # The mistyped subcommand is the first non-flag argument after `kubectl`.
+    misspelled_command = command.script_parts[1]
+
+    suggestions = _get_suggestions(command.output)
+    if suggestions:
+        return [replace_argument(command.script, misspelled_command, s)
+                for s in suggestions]
+
+    return []


### PR DESCRIPTION
## Summary
Adds a new correction rule for `kubectl` when an unknown or mistyped subcommand is executed (e.g. `kubectl gat pods` -> `kubectl get pods`).

## Details
- Parses `Did you mean this?` suggestions provided by `kubectl`
- Supports both single and multiple suggestion outputs
- Compatible with modern (>= 1.26) and older `kubectl` versions
- Preserves all arguments and flags (e.g. `-n kube-system`, `-f deploy.yaml`)
- Includes full unit test suite (`tests/rules/test_kubectl_unknown_command.py`) with 100% pass rate
- Passes `flake8` and `tests/test_rule_quality.py` checks
