### PR TITLE
feat(rules): add correction rule for mistyped uv subcommands

### DIFF
--- a/tests/rules/test_uv_unknown_subcommand.py
+++ b/tests/rules/test_uv_unknown_subcommand.py
@@ -1,0 +1,110 @@
+# -*- encoding: utf-8 -*-
+
+import pytest
+from thebleep.rules.uv_unknown_subcommand import (
+    _get_broken, _get_suggestions, get_new_command, match)
+from thebleep.types import Command
+
+# `uv piip install requests` -- single suggestion.
+ONE = (
+    "error: unrecognized subcommand 'piip'\n"
+    "\n"
+    "  tip: a similar subcommand exists: 'pip'\n"
+    "Usage: uv [OPTIONS] <COMMAND>\n"
+    "For more information, try '--help'.\n"
+)
+
+# `uv re` -- multiple suggestions.
+MANY = (
+    "error: unrecognized subcommand 're'\n"
+    "\n"
+    "  tip: some similar subcommands exist: 'remove', 'tree'\n"
+    "Usage: uv [OPTIONS] <COMMAND>\n"
+    "For more information, try '--help'.\n"
+)
+
+# `uv pip instll requests` -- nested subcommand.
+NESTED = (
+    "error: unrecognized subcommand 'instll'\n"
+    "\n"
+    "  tip: a similar subcommand exists: 'install'\n"
+    "Usage: uv pip <COMMAND>\n"
+    "For more information, try '--help'.\n"
+)
+
+# `uv zzzzzz` -- nothing close, no tip offered.
+NOTHING = (
+    "error: unrecognized subcommand 'zzzzzz'\n"
+    "\n"
+    "Usage: uv [OPTIONS] <COMMAND>\n"
+    "For more information, try '--help'.\n"
+)
+
+
+class TestReadingOutput(object):
+    def test_broken_subcommand(self):
+        assert _get_broken(ONE) == 'piip'
+        assert _get_broken(MANY) == 're'
+        assert _get_broken(NESTED) == 'instll'
+        assert _get_broken(NOTHING) == 'zzzzzz'
+
+    def test_single_suggestion(self):
+        assert _get_suggestions(ONE) == ['pip']
+
+    def test_multiple_suggestions(self):
+        assert _get_suggestions(MANY) == ['remove', 'tree']
+
+    def test_nested_suggestion(self):
+        assert _get_suggestions(NESTED) == ['install']
+
+    def test_none_offered(self):
+        assert _get_suggestions(NOTHING) == []
+
+
+class TestMatching(object):
+    @pytest.mark.parametrize('script, output', [
+        ('uv piip install requests', ONE),
+        ('uv re', MANY),
+        ('uv pip instll requests', NESTED),
+    ])
+    def test_an_unknown_subcommand(self, script, output):
+        assert match(Command(script, output))
+
+    @pytest.mark.parametrize('script, output', [
+        ('uv pip install requests', ''),
+        ('uv --help', 'An extremely fast Python package manager.'),
+        # Somebody else's output.
+        ('cargo piip', ONE),
+        # When uv has nothing to suggest.
+        ('uv zzzzzz', NOTHING),
+    ])
+    def test_not_matching(self, script, output):
+        assert not match(Command(script, output))
+
+
+class TestCorrecting(object):
+    def test_one_suggestion(self):
+        assert get_new_command(
+            Command('uv piip install requests', ONE)) == [
+                'uv pip install requests']
+
+    def test_multiple_suggestions(self):
+        assert get_new_command(Command('uv re', MANY)) == [
+            'uv tree', 'uv remove']
+
+    def test_nested_subcommand(self):
+        assert get_new_command(
+            Command('uv pip instll requests', NESTED)) == [
+                'uv pip install requests']
+
+    def test_flags_are_kept(self):
+        assert get_new_command(
+            Command('uv --directory /tmp piip install requests', ONE)) == [
+                'uv --directory /tmp pip install requests']
+
+    def test_a_suggestion_is_quoted(self):
+        hostile = ONE.replace("'pip'", "'pip;>PWNED'")
+        suggestions = get_new_command(
+            Command('uv piip install requests', hostile))
+        assert "uv 'pip;>PWNED' install requests" in suggestions
+        assert 'uv pip;>PWNED install requests' not in suggestions

--- a/tests/test_injection.py
+++ b/tests/test_injection.py
@@ -47,7 +47,7 @@ def canary(tmpdir):
     stub.chmod(0o755)
     for name in ('git', 'az', 'composer', 'grunt', 'npm', 'yarn', 'gradle',
                  'sh', 'env', 'rm', 'kill', 'ssh', 'ssh-keygen', 'vim',
-                 'rails', 'kubectl'):
+                 'rails', 'kubectl', 'uv'):
         shutil.copy(str(stub), str(stubs.join(name)))
 
     work = tmpdir.mkdir('work')
@@ -268,4 +268,16 @@ class TestNamesFromSomewhereElse(object):
         if not kubectl_unknown_command.match(command):
             return
         for suggestion in kubectl_unknown_command.get_new_command(command):
+            assert canary(suggestion) == []
+
+    def test_uv(self, name, payload, canary):
+        """uv lists what it thinks you meant, and we repeat one back."""
+        from thebleep.rules import uv_unknown_subcommand
+
+        output = (u"error: unrecognized subcommand 'piip'\n\n"
+                  u"  tip: a similar subcommand exists: '{}'\n\n".format(payload))
+        command = Command(u'uv piip install requests', output)
+        if not uv_unknown_subcommand.match(command):
+            return
+        for suggestion in uv_unknown_subcommand.get_new_command(command):
             assert canary(suggestion) == []

--- a/thebleep/rules/uv_unknown_subcommand.py
+++ b/thebleep/rules/uv_unknown_subcommand.py
@@ -1,0 +1,55 @@
+# -*- encoding: utf-8 -*-
+
+"""`uv piip install requests` -> `uv pip install requests`.
+
+uv reports unrecognized subcommands and offers suggestions when a close
+command exists:
+
+    error: unrecognized subcommand 'piip'
+
+      tip: a similar subcommand exists: 'pip'
+
+When multiple subcommands match:
+
+    error: unrecognized subcommand 're'
+
+      tip: some similar subcommands exist: 'remove', 'tree'
+
+Subcommands under namespaces (`uv pip instll`, `uv tool runn`) print the same
+tip block naming the subcommand in question.
+
+"""
+
+import re
+from thebleep.utils import for_app, replace_command
+
+UNRECOGNIZED = re.compile(r"error: unrecognized subcommand '([^']+)'")
+TIP = re.compile(
+    r"tip: (?:a similar subcommand exists|some similar subcommands exist):\s*(.+)")
+
+
+def _get_broken(output):
+    found = UNRECOGNIZED.search(output)
+    return found and found.group(1)
+
+
+def _get_suggestions(output):
+    """Subcommands uv offered, extracted from the tip line."""
+    for line in output.split('\n'):
+        found = TIP.search(line)
+        if found:
+            return re.findall(r"'([^']+)'", found.group(1))
+    return []
+
+
+@for_app('uv', at_least=1)
+def match(command):
+    return ('unrecognized subcommand' in command.output
+            and bool(_get_broken(command.output))
+            and bool(_get_suggestions(command.output)))
+
+
+def get_new_command(command):
+    broken = _get_broken(command.output)
+    suggestions = _get_suggestions(command.output)
+    return replace_command(command, broken, suggestions)


### PR DESCRIPTION
## Summary
Adds a new correction rule for `uv` (Astral's Python package and project manager) when an unknown or mistyped subcommand is executed (e.g., `uv piip install requests` -> `uv pip install requests`, `uv pip instll` -> `uv pip install`).

## Details
- Extracts suggestions from `uv`'s `tip: a similar subcommand exists: '...'` and `tip: some similar subcommands exist: '...', '...'` output blocks
- Works with top-level subcommands as well as nested command namespaces (`uv pip`, `uv tool`, `uv python`)
- Uses `replace_command` to sort suggestions by closeness, quote untrusted tokens, and preserve flags/options
- Rejects commands when no suggestions are offered by `uv` or when non-`uv` tools run
- Includes 17 comprehensive unit tests (`tests/rules/test_uv_unknown_subcommand.py`) with 100% pass rate
- Added `test_uv` to `tests/test_injection.py` to ensure injection safety
- Passes `flake8` and `tests/test_rule_quality.py` checks with 0 errors
