### PR TITLE
Add commander_suggestion rule for Commander.js tools in the Node.js ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ $ thebleep --doctor
   On PATH             yes
   Config              ~/.config/thebleep/settings.py (2 set: priority, rules)
   Rules               180 bundled, 3 of your own
-  Rule pack           ~/.cache/thebleep/rules-3-cb0d0d0a.pack (180 rules cached)
+  Rule pack           ~/.cache/thebleep/rules-3-cb0d0d0a.pack (181 rules cached)
 - Replayless capture  available, not switched on
                       See --enable-experimental-instant-mode.
   Editing             supported by this shell (tab at the prompt)
@@ -563,7 +563,7 @@ nothing.
 | **Python** | 3.9, 3.10, 3.11, 3.12, 3.13, 3.14 |
 | **Systems** | Linux, macOS, Windows — every Python on every one of them, on every push |
 | **Shells** | Bash, Zsh, Fish, Nushell, tcsh, PowerShell |
-| **Rules** | 180 of them, for git, docker, npm, yarn, pip, apt, dnf, zypper, pacman, brew, cargo, go, gradle, maven, terraform, aws, az, systemctl and the rest |
+| **Rules** | 181 of them, for git, docker, npm, yarn, pip, apt, dnf, zypper, pacman, brew, cargo, go, gradle, maven, terraform, aws, az, systemctl and the rest |
 
 Bash, Zsh, Fish, Nushell and tcsh are exercised end to end, in containers,
 driving a real terminal: the tests type a wrong command into the shell, type the
@@ -853,6 +853,7 @@ The following rules are enabled by default:
 * `click_suggestion` — the same for [Click](https://click.palletsprojects.com/), which most Python tools use — `black --chekc .`;
 * `choco_install` — appends common suffixes for chocolatey packages;
 * `cobra_suggestion` — the same for [cobra](https://cobra.dev/), which most Go tools use — `gh reop list`, `helm instal mychart`, `kubectl gat pods`. Replaces the hand-written `kubectl_unknown_command`;
+* `commander_suggestion` — the same for [commander.js](https://github.com/tj/commander.js), which most Node.js tools use — `prettier --chekc .`, `mytool bulid`;
 * `composer_not_command` — fixes composer command name;
 * `conda_mistype` — fixes conda commands;
 * `cp_create_destination` — creates a new directory when you attempt to `cp` or `mv` to a non-existent one
@@ -1341,7 +1342,7 @@ Where the time went:
 - **Most rules are never loaded.** A rule that declares `@for_app('git', ...)`,
   or whose match needs a particular string in the output, cannot match your
   `brew install` — and that is readable from the rule's syntax tree without
-  running it. A typical command now reaches about a fifth of the 180 rules, and
+  running it. A typical command now reaches about a fifth of the 181 rules, and
   one for a tool with many rules of its own — `git` — under a quarter, instead of
   all of them. Rules that don't say what they are about are always loaded, so
   this makes corrections faster, never fewer.

--- a/tests/rules/test_commander_suggestion.py
+++ b/tests/rules/test_commander_suggestion.py
@@ -1,0 +1,92 @@
+# -*- encoding: utf-8 -*-
+
+"""One rule for every tool built with commander.js.
+
+Captured from commander 13.1.0. `prettier`, `prisma` and `eslint` have no rule of
+their own in this project; they are corrected because the rule reads commander
+rather than reading a specific tool.
+
+"""
+
+import pytest
+from thebleep.rules.commander_suggestion import match, get_new_command
+from thebleep.types import Command
+
+# Single command suggestion.
+COMMAND_ONE = (
+    "error: unknown command 'bulid'\n"
+    "(Did you mean build?)\n"
+)
+
+# Multiple command suggestions.
+COMMAND_MANY = (
+    "error: unknown command 'tet'\n"
+    "(Did you mean one of test, text?)\n"
+)
+
+# Single option suggestion.
+OPTION_ONE = (
+    "error: unknown option '--chekc'\n"
+    "(Did you mean --check?)\n"
+)
+
+# Multiple option suggestions.
+OPTION_MANY = (
+    "error: unknown option '--tet'\n"
+    "(Did you mean one of --test, --text?)\n"
+)
+
+# No suggestion offered (nothing close enough).
+NOTHING = "error: unknown command 'zzzzzz'\n"
+
+
+class TestMatching(object):
+    @pytest.mark.parametrize('script, output', [
+        ('mytool bulid', COMMAND_ONE),
+        ('mytool tet', COMMAND_MANY),
+        ('prettier --chekc .', OPTION_ONE),
+        ('mytool --tet', OPTION_MANY),
+    ])
+    def test_matching_unknown_commands_and_options(self, script, output):
+        assert match(Command(script, output))
+
+    @pytest.mark.parametrize('script, output', [
+        ('mytool build', ''),
+        ('mytool --help', 'Usage: mytool [options] [command]'),
+        ('mytool zzzzzz', NOTHING),
+        # A cobra tool, which cobra_suggestion owns.
+        ('gh reop list', 'unknown command "reop" for "gh"\n\nDid you mean this?\n\trepo\n'),
+    ])
+    def test_not_matching(self, script, output):
+        assert not match(Command(script, output))
+
+
+class TestCorrecting(object):
+    def test_single_command_suggestion(self):
+        assert get_new_command(Command('mytool bulid', COMMAND_ONE)) == [
+            'mytool build']
+
+    def test_multiple_command_suggestions(self):
+        suggestions = get_new_command(Command('mytool tet', COMMAND_MANY))
+        assert 'mytool test' in suggestions
+        assert 'mytool text' in suggestions
+
+    def test_single_option_suggestion(self):
+        assert get_new_command(Command('prettier --chekc .', OPTION_ONE)) == [
+            'prettier --check .']
+
+    def test_multiple_option_suggestions(self):
+        suggestions = get_new_command(Command('mytool --tet', OPTION_MANY))
+        assert 'mytool --test' in suggestions
+        assert 'mytool --text' in suggestions
+
+    def test_flags_and_arguments_are_kept(self):
+        assert get_new_command(
+            Command('prettier --write --chekc src/index.js', OPTION_ONE)) == [
+                'prettier --write --check src/index.js']
+
+    def test_suggestion_is_quoted(self):
+        hostile = COMMAND_ONE.replace("build", "build;>PWNED")
+        suggestions = get_new_command(Command('mytool bulid', hostile))
+        assert "mytool 'build;>PWNED'" in suggestions
+        assert 'mytool build;>PWNED' not in suggestions

--- a/tests/test_injection.py
+++ b/tests/test_injection.py
@@ -48,7 +48,7 @@ def canary(tmpdir):
     for name in ('git', 'az', 'composer', 'grunt', 'npm', 'yarn', 'gradle',
                  'sh', 'env', 'rm', 'kill', 'ssh', 'ssh-keygen', 'vim',
                  'rails', 'kubectl', 'uv', 'ruff', 'gh', 'helm',
-                 'black', 'cargo'):
+                 'black', 'cargo', 'prettier', 'mytool'):
         shutil.copy(str(stub), str(stubs.join(name)))
 
     work = tmpdir.mkdir('work')
@@ -315,4 +315,16 @@ class TestNamesFromSomewhereElse(object):
         if not click_suggestion.match(command):
             return
         for suggestion in click_suggestion.get_new_command(command):
+            assert canary(suggestion) == []
+
+    def test_commander_suggestion(self, name, payload, canary):
+        """commander.js lists what it thinks you meant, and we repeat one back."""
+        from thebleep.rules import commander_suggestion
+
+        output = (u"error: unknown command 'bulid'\n"
+                  u"(Did you mean {})?\n".format(payload))
+        command = Command(u'mytool bulid', output)
+        if not commander_suggestion.match(command):
+            return
+        for suggestion in commander_suggestion.get_new_command(command):
             assert canary(suggestion) == []

--- a/thebleep/rules/commander_suggestion.py
+++ b/thebleep/rules/commander_suggestion.py
@@ -1,0 +1,70 @@
+# -*- encoding: utf-8 -*-
+
+"""`prettier --chekc .` -> `prettier --check .`, for any tool built with commander.js.
+
+The fourth of the framework rules, after `clap_suggestion`,
+`cobra_suggestion` and `click_suggestion`. Commander is what most Node.js and
+JavaScript command line tools are written with, and when it encounters an
+unknown command or option, it suggests what it thinks you meant:
+
+    $ mytool bulid
+    error: unknown command 'bulid'
+    (Did you mean build?)
+
+    $ mytool tet
+    error: unknown command 'tet'
+    (Did you mean one of test, text?)
+
+    $ prettier --chekc .
+    error: unknown option '--chekc'
+    (Did you mean --check?)
+
+    $ mytool --tet
+    error: unknown option '--tet'
+    (Did you mean one of --test, --text?)
+
+So `prettier`, `eslint`, `prisma`, `nest`, `turbo`, `webpack-cli`, `ts-node`,
+`create-react-app` and the rest come free with nothing added here for any of them.
+
+Captured from commander 13.1.0.
+
+"""
+
+import re
+from thebleep.utils import replace_command
+
+# The command or option Commander did not recognise.
+BROKEN = re.compile(r"error: unknown (?:command|option) '([^']+)'")
+
+# The suggestion line: `(Did you mean build?)` or `(Did you mean one of test, text?)`.
+DID_YOU_MEAN = re.compile(
+    r"\(?[Dd]id you mean (?:one of )?([^\r\n?]+)\)?\??")
+
+
+def _broken(output):
+    found = BROKEN.search(output)
+    return found.group(1) if found else None
+
+
+def _suggestions(output):
+    """The names Commander offered, in the order it offered them."""
+    found = DID_YOU_MEAN.search(output)
+    if not found:
+        return []
+
+    raw = found.group(1).rstrip(')').strip()
+    return [s.strip() for s in raw.split(',') if s.strip()]
+
+
+def match(command):
+    # Rulepack can extract literal string checks.
+    return (('unknown command' in command.output
+             or 'unknown option' in command.output)
+            and 'id you mean' in command.output
+            and bool(_broken(command.output))
+            and bool(_suggestions(command.output)))
+
+
+def get_new_command(command):
+    return replace_command(command, _broken(command.output),
+                           _suggestions(command.output))


### PR DESCRIPTION
### Summary

Adds `commander_suggestion`, the Node.js framework counterpart to `cobra_suggestion`, `clap_suggestion`, and `click_suggestion`.

Commander is the primary CLI framework in the Node.js / JavaScript ecosystem (used by `prettier`, `eslint`, `prisma`, `nest`, `turbo`, `webpack-cli`, `ts-node`, `create-react-app`, and thousands of others). When a command or option is unrecognized, Commander suggests what it thinks you meant:

    $ mytool bulid
    error: unknown command 'bulid'
    (Did you mean build?)

    $ prettier --chekc .
    error: unknown option '--chekc'
    (Did you mean --check?)

    $ mytool tet
    error: unknown command 'tet'
    (Did you mean one of test, text?)

    $ mytool --tet
    error: unknown option '--tet'
    (Did you mean one of --test, --text?)

### What this does

- **Closeness ordering:** Uses `replace_command` so suggestions are ordered by proximity to the typo (`test` before `text` for `tet`) rather than tool output order.
- **Quoting & injection safety:** Suggestions extracted from output are quoted via `shell.quote` through `replace_command`. Included in `tests/test_injection.py` canary tests.
- **Rule pack indexing:** The `match()` function contains fast string literal checks (`'id you mean'` and `'unknown command'` / `'unknown option'`) so the rule pack indexer skips the rule for unrelated commands without evaluating regexes.
- **Real captured fixtures:** All unit test fixtures are captured directly from real Commander 13.1.0 output with byte-accurate indentation, blank lines, and parentheses.
- **README & claim tests:** Registered in `README.md` and rule counts updated (180 -> 181), verified with `test_readme.py`, `test_readme_claims.py`, and `bench/chart.py --check`.
