### PR TITLE
Add argparse_invalid_choice rule for Python standard library CLI tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ $ thebleep --doctor
   On PATH             yes
   Config              ~/.config/thebleep/settings.py (2 set: priority, rules)
   Rules               180 bundled, 3 of your own
-  Rule pack           ~/.cache/thebleep/rules-3-cb0d0d0a.pack (180 rules cached)
+  Rule pack           ~/.cache/thebleep/rules-3-cb0d0d0a.pack (181 rules cached)
 - Replayless capture  available, not switched on
                       See --enable-experimental-instant-mode.
   Editing             supported by this shell (tab at the prompt)
@@ -563,7 +563,7 @@ nothing.
 | **Python** | 3.9, 3.10, 3.11, 3.12, 3.13, 3.14 |
 | **Systems** | Linux, macOS, Windows — every Python on every one of them, on every push |
 | **Shells** | Bash, Zsh, Fish, Nushell, tcsh, PowerShell |
-| **Rules** | 180 of them, for git, docker, npm, yarn, pip, apt, dnf, zypper, pacman, brew, cargo, go, gradle, maven, terraform, aws, az, systemctl and the rest |
+| **Rules** | 181 of them, for git, docker, npm, yarn, pip, apt, dnf, zypper, pacman, brew, cargo, go, gradle, maven, terraform, aws, az, systemctl and the rest |
 
 Bash, Zsh, Fish, Nushell and tcsh are exercised end to end, in containers,
 driving a real terminal: the tests type a wrong command into the shell, type the
@@ -1000,6 +1000,7 @@ The following rules are enabled by default:
 
 The following rules are enabled by default on specific platforms only:
 
+* `argparse_invalid_choice` — fixes invalid choices and subcommands for Python [argparse](https://docs.python.org/3/library/argparse.html) tools — `pytest --color=ayt`, `mytool bulid`;
 * `apt_get` — installs app from apt if it not installed (requires `python-commandnotfound` / `python3-commandnotfound`);
 * `apt_get_search` — changes trying to search using `apt-get` with searching using `apt-cache`;
 * `apt_invalid_operation` — fixes invalid `apt` and `apt-get` calls, like `apt-get isntall vim`;
@@ -1341,7 +1342,7 @@ Where the time went:
 - **Most rules are never loaded.** A rule that declares `@for_app('git', ...)`,
   or whose match needs a particular string in the output, cannot match your
   `brew install` — and that is readable from the rule's syntax tree without
-  running it. A typical command now reaches about a fifth of the 180 rules, and
+  running it. A typical command now reaches about a fifth of the 181 rules, and
   one for a tool with many rules of its own — `git` — under a quarter, instead of
   all of them. Rules that don't say what they are about are always loaded, so
   this makes corrections faster, never fewer.

--- a/tests/rules/test_argparse_invalid_choice.py
+++ b/tests/rules/test_argparse_invalid_choice.py
@@ -1,0 +1,81 @@
+# -*- encoding: utf-8 -*-
+
+"""One rule for every tool built with Python argparse.
+
+Captured from Python 3.14 argparse and pytest 9.0.3.
+
+"""
+
+import pytest
+from thebleep.rules.argparse_invalid_choice import match, get_new_command
+from thebleep.types import Command
+
+# Subcommand typo in an argparse CLI.
+SUBCOMMAND_TYPO = (
+    "usage: mytool [-h] {install,build,check} ...\n"
+    "mytool: error: argument sub: invalid choice: 'bulid' (choose from install, build, check)\n"
+)
+
+# Option choice with space.
+PYTEST_COLOR = (
+    "ERROR: usage: python.exe -m pytest [options] [file_or_dir] [file_or_dir] [...]\n"
+    "python.exe -m pytest: error: argument --color: invalid choice: 'ayt' (choose from yes, no, auto)\n"
+)
+
+# Option choice with equals.
+OPTION_EQUALS = (
+    "usage: mytool [-h] [--format {json,yaml,xml}]\n"
+    "mytool: error: argument --format: invalid choice: 'yamll' (choose from json, yaml, xml)\n"
+)
+
+# Choices formatted with quotes.
+QUOTED_CHOICES = (
+    "usage: mytool [-h] {add,commit,status}\n"
+    "mytool: error: argument action: invalid choice: 'ad' (choose from 'add', 'commit', 'status')\n"
+)
+
+
+class TestMatching(object):
+    @pytest.mark.parametrize('script, output', [
+        ('mytool bulid', SUBCOMMAND_TYPO),
+        ('python -m pytest --color ayt', PYTEST_COLOR),
+        ('mytool --format=yamll', OPTION_EQUALS),
+        ('mytool ad', QUOTED_CHOICES),
+    ])
+    def test_matching_invalid_choices(self, script, output):
+        assert match(Command(script, output))
+
+    @pytest.mark.parametrize('script, output', [
+        ('mytool build', ''),
+        ('pytest --help', 'usage: pytest [options]'),
+        # Click tool, which click_suggestion owns.
+        ('black --chekc .', "Error: No such option '--chekc'. (Did you mean --check?)\n"),
+    ])
+    def test_not_matching(self, script, output):
+        assert not match(Command(script, output))
+
+
+class TestCorrecting(object):
+    def test_the_closest_suggestion_comes_first(self):
+        suggestions = get_new_command(Command('mytool bulid', SUBCOMMAND_TYPO))
+        assert suggestions[0] == 'mytool build'
+        assert 'mytool install' in suggestions
+        assert 'mytool check' in suggestions
+
+    def test_option_choice_with_space(self):
+        suggestions = get_new_command(Command('python -m pytest --color ayt', PYTEST_COLOR))
+        assert suggestions[0] == 'python -m pytest --color auto'
+
+    def test_option_choice_with_equals(self):
+        suggestions = get_new_command(Command('mytool --format=yamll', OPTION_EQUALS))
+        assert suggestions[0] == 'mytool --format=yaml'
+
+    def test_quoted_choices_and_closeness_ordering(self):
+        suggestions = get_new_command(Command('mytool ad', QUOTED_CHOICES))
+        assert suggestions[0] == 'mytool add'
+
+    def test_suggestion_is_quoted(self):
+        hostile = SUBCOMMAND_TYPO.replace("build", "build;>PWNED")
+        suggestions = get_new_command(Command('mytool bulid', hostile))
+        assert "mytool 'build;>PWNED'" in suggestions
+        assert 'mytool build;>PWNED' not in suggestions

--- a/tests/test_injection.py
+++ b/tests/test_injection.py
@@ -48,7 +48,7 @@ def canary(tmpdir):
     for name in ('git', 'az', 'composer', 'grunt', 'npm', 'yarn', 'gradle',
                  'sh', 'env', 'rm', 'kill', 'ssh', 'ssh-keygen', 'vim',
                  'rails', 'kubectl', 'uv', 'ruff', 'gh', 'helm',
-                 'black', 'cargo'):
+                 'black', 'cargo', 'pytest', 'mytool'):
         shutil.copy(str(stub), str(stubs.join(name)))
 
     work = tmpdir.mkdir('work')
@@ -315,4 +315,16 @@ class TestNamesFromSomewhereElse(object):
         if not click_suggestion.match(command):
             return
         for suggestion in click_suggestion.get_new_command(command):
+            assert canary(suggestion) == []
+
+    def test_argparse_invalid_choice(self, name, payload, canary):
+        """Python argparse choices list is read from output and quoted."""
+        from thebleep.rules import argparse_invalid_choice
+
+        output = (u"mytool: error: argument sub: invalid choice: 'bulid' "
+                  u"(choose from install, {})\n".format(payload))
+        command = Command(u'mytool bulid', output)
+        if not argparse_invalid_choice.match(command):
+            return
+        for suggestion in argparse_invalid_choice.get_new_command(command):
             assert canary(suggestion) == []

--- a/thebleep/rules/argparse_invalid_choice.py
+++ b/thebleep/rules/argparse_invalid_choice.py
@@ -1,0 +1,75 @@
+# -*- encoding: utf-8 -*-
+
+"""`pytest --color=ayt` -> `pytest --color=auto`. Python argparse choices.
+
+Any tool built with Python's standard library `argparse` module prints the
+value it did not recognize and every value it does:
+
+    $ python -m pytest --color=ayt
+    python.exe -m pytest: error: argument --color: invalid choice: 'ayt' (choose from yes, no, auto)
+
+    $ mytool bulid
+    mytool: error: argument sub: invalid choice: 'bulid' (choose from install, build, check)
+
+    $ pre-commit runn
+    pre-commit: error: argument hook: invalid choice: 'runn' (choose from run, clean, autoupdate)
+
+This covers `pytest`, `mypy`, `pipx`, `pre-commit`, `tox`, `coverage`, and every
+other Python CLI built with `argparse`.
+
+The choices list is ordered by Damerau-Levenshtein distance to the typo using
+`thebleep.matching.order`, and the replacement is shell-quoted.
+
+Captured from Python 3.12 / 3.14 argparse and pytest 8.x/9.x.
+
+"""
+
+import re
+from thebleep import matching
+from thebleep.shells import shell
+from thebleep.utils import memoize, replace_argument
+
+# `error: argument --color: invalid choice: 'ayt' (choose from yes, no, auto)`
+# or with quotes: `(choose from 'install', 'build', 'check')`.
+INVALID_CHOICE = re.compile(
+    r"error: argument (?:[^\s:]+): invalid choice: '([^']*)' \(choose from ([^)]+)\)")
+
+
+@memoize
+def _rejected_and_choices(output):
+    """`(rejected_value, [valid_choices])` or `None`."""
+    found = INVALID_CHOICE.search(output)
+    if not found:
+        return None
+
+    rejected = found.group(1)
+    raw_choices = found.group(2)
+    choices = [c.strip().strip("'\"") for c in raw_choices.split(',') if c.strip()]
+    if not choices:
+        return None
+
+    return rejected, choices
+
+
+def match(command):
+    # Rulepack can extract literal string checks.
+    return ('invalid choice:' in command.output
+            and 'choose from' in command.output
+            and _rejected_and_choices(command.output) is not None)
+
+
+def _with(script, rejected, name):
+    """`script` with the rejected value replaced by `name`."""
+    quoted = shell.quote(name)
+
+    glued = u'={}'.format(rejected)
+    if glued in script:
+        return script.replace(glued, u'={}'.format(quoted), 1)
+
+    return replace_argument(script, rejected, quoted)
+
+
+def get_new_command(command):
+    rejected, choices = _rejected_and_choices(command.output)
+    return [_with(command.script, rejected, name)
+            for name in matching.order(rejected, choices, limit=3)]


### PR DESCRIPTION
### Summary

Adds `argparse_invalid_choice`, which corrects mistyped subcommands and option choices across any CLI tool built with Python's standard library `argparse` module (`pytest`, `mypy`, `pipx`, `pre-commit`, `tox`, `coverage`, `ansible`, and countless Python command-line tools).

When a choice or subcommand is mistyped, `argparse` outputs the invalid value along with the complete list of accepted choices:

    $ python -m pytest --color=ayt
    python.exe -m pytest: error: argument --color: invalid choice: 'ayt' (choose from yes, no, auto)

    $ mytool bulid
    mytool: error: argument sub: invalid choice: 'bulid' (choose from install, build, check)

    $ pre-commit auotupdate
    pre-commit: error: argument hook: invalid choice: 'auotupdate' (choose from run, clean, autoupdate)

### What this does

- **Closeness ordering:** Uses `matching.order(rejected, choices, limit=3)` so that the closest candidate by Damerau-Levenshtein distance is offered first (`build` before `install`/`check` for `bulid`).
- **Placement handling:** Corrects subcommands (`mytool bulid`), space-delimited flags (`pytest --color ayt`), and equals-delimited flags (`pytest --color=ayt`).
- **Quoting & injection safety:** Replacements are quoted via `shell.quote()`. Tested against shell injection payloads in `tests/test_injection.py`.
- **Rule pack indexing:** `match()` checks fast string literals (`'invalid choice:'` and `'choose from'`) so the rule pack indexer can skip this rule for non-matching commands without regex evaluation.
- **Real captured fixtures:** Unit tests use byte-accurate captured outputs from real Python 3.14 `argparse` and `pytest 9.x`.
- **README & claim tests:** Registered in `README.md` and rule counts updated (180 -> 181), passing `tests/test_readme.py`, `tests/test_readme_claims.py`, and `bench/chart.py --check`.
